### PR TITLE
Allow users to mark versions as "dead"

### DIFF
--- a/public/components/ChannelVersionList.tsx
+++ b/public/components/ChannelVersionList.tsx
@@ -30,6 +30,7 @@ interface ChannelVersionListState {
   modalVersion: PossiblePreReleaseVersion | null;
   modalOpen: boolean;
   releasing: boolean;
+  killing: boolean;
 }
 
 export default class ChannelVersionList extends React.PureComponent<ChannelVersionListProps, ChannelVersionListState> {
@@ -39,6 +40,7 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
     modalVersion: null as (PossiblePreReleaseVersion | null),
     modalOpen: false,
     releasing: false,
+    killing: false,
   };
 
   componentDidMount() {
@@ -48,6 +50,17 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
   componentDidUpdate(prevProps: ChannelVersionListProps) {
     if (prevProps.app.id !== this.props.app.id || prevProps.channel.id !== this.props.channel.id) {
       this.fetch();
+    }
+    if (this.state.modalVersion) {
+      const foundVersion = this.props.channel.versions.find(version => version.name === this.state.modalVersion.version.name);
+      if (!foundVersion) return;
+      if (JSON.stringify(this.state.modalVersion.version) !== JSON.stringify(foundVersion)) {
+        this.setState({
+          modalVersion: Object.assign({}, this.state.modalVersion, {
+            version: foundVersion,
+          }),
+        });
+      }
     }
   }
 
@@ -113,7 +126,7 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
             ? <h5>No Released Versions</h5>
             : (
               this.props.channel.versions.map((version, index) => (
-                <div key={index} className={styles.versionSelect} onClick={this.showVersionModal(version)}>
+                <div key={index} className={styles.versionSelect} onClick={this.showVersionModal(version)} style={{ color: version.dead ? 'red' : 'inherit', textDecoration: version.dead ? 'line-through' : '' }}>
                   {version.name}
                 </div>
               ))
@@ -194,10 +207,52 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
     }
   }
 
+  private toggleVersionDeath = async () => {
+    if (this.state.modalVersion && !this.state.modalVersion.isPreRelease) {
+      if (!confirm(`Are you sure you want to ${this.state.modalVersion.version.dead ? 'bring this version back to life?' : 'mark this version as dead?'}`)) return;
+      this.setState({
+        killing: true,
+      });
+      const response = await fetch(`/rest/app/${this.props.app.id}/channel/${this.props.channel.id}/dead`, {
+        credentials: 'include',
+        method: 'POST',
+        body: JSON.stringify({
+          version: this.state.modalVersion.version.name,
+          dead: !this.state.modalVersion.version.dead,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      await this.props.updateApps(false);
+      this.setState({
+        killing: false,
+      });
+    }
+  }
+
+  get killButton() {
+    if (!this.state.modalVersion) return null;
+    let appearance = 'danger';
+    let text = 'Mark as Dead';
+    if (this.state.modalVersion.version.dead) {
+      appearance = 'help';
+      text = 'Revive';
+    }
+    return <AkButton appearance={appearance} onClick={this.toggleVersionDeath} isDisabled={this.state.killing}>{text}</AkButton>;
+  }
+
   render() {
     if (this.state.loading) {
       return <AkSpinner size={40} />;
     }
+    let foundIndex = -1;
+    this.props.channel.versions.find((version, index) => {
+      if (this.state.modalVersion && version.name === this.state.modalVersion.version.name) {
+        foundIndex = index;
+      }
+    });
+    const notLastVersion = foundIndex < this.props.channel.versions.length - 1;
     return (
       <div style={{ width: '100%' }}>
         <AkTabs
@@ -209,6 +264,8 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
             <AkModalDialog
               header={<h4 style={{ marginBottom: 0 }}>Version: {this.state.modalVersion.version.name}</h4>}
               footer={<div style={{ textAlign: 'right' }}>
+                { !this.state.modalVersion.isPreRelease && notLastVersion ? this.killButton : null }
+                { !this.state.modalVersion.isPreRelease && notLastVersion ? <div style={{ marginRight: 8, display: 'inline-block' }} /> : null }
                 <AkButton appearance="primary" onClick={this.closeModal} isDisabled={this.state.releasing}>Done</AkButton>
                 { this.state.modalVersion.isPreRelease ? <div style={{ marginRight: 8, display: 'inline-block' }} /> : null }
                 { this.state.modalVersion.isPreRelease ? <AkButton appearance="primary" onClick={this.release} isDisabled={this.state.releasing}>Release</AkButton> : null }
@@ -223,6 +280,14 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
                 ? (
                   <AkBanner icon={<WarningIcon label="Warning" />} isOpen>
                     This is a set of pre-release files, click Publish to make them public
+                  </AkBanner>
+                ) : null
+              }
+              {
+                this.state.modalVersion.version.dead
+                ? (
+                  <AkBanner icon={<WarningIcon label="Warning" />} isOpen>
+                    This version has been marked as dead
                   </AkBanner>
                 ) : null
               }

--- a/public/components/ChannelVersionList.tsx
+++ b/public/components/ChannelVersionList.tsx
@@ -213,16 +213,16 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
       this.setState({
         killing: true,
       });
+      const headers = new Headers();
+      headers.append('Content-Type', 'application/json');
       const response = await fetch(`/rest/app/${this.props.app.id}/channel/${this.props.channel.id}/dead`, {
+        headers,
         credentials: 'include',
         method: 'POST',
         body: JSON.stringify({
           version: this.state.modalVersion.version.name,
           dead: !this.state.modalVersion.version.dead,
         }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
       });
       await this.props.updateApps(false);
       this.setState({
@@ -239,7 +239,7 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
       appearance = 'help';
       text = 'Revive';
     }
-    return <AkButton appearance={appearance} onClick={this.toggleVersionDeath} isDisabled={this.state.killing}>{text}</AkButton>;
+    return <AkButton appearance={appearance as any} onClick={this.toggleVersionDeath} isDisabled={this.state.killing}>{text}</AkButton>;
   }
 
   render() {
@@ -247,7 +247,7 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
       return <AkSpinner size={40} />;
     }
     let foundIndex = -1;
-    this.props.channel.versions.find((version, index) => {
+    this.props.channel.versions.forEach((version, index) => {
       if (this.state.modalVersion && version.name === this.state.modalVersion.version.name) {
         foundIndex = index;
       }

--- a/src/db/BaseDriver.ts
+++ b/src/db/BaseDriver.ts
@@ -43,6 +43,14 @@ export default abstract class BaseDriver extends IDBDriver {
     });
   }
 
+  protected writeVersionsFileToStore = async (app: NucleusApp, channel: NucleusChannel) => {
+    const versionsToWrite = Object.assign({}, (await this.getApp(app.id)))
+      .channels
+      .find(testChannel => testChannel.id === channel.id)
+      .versions;
+    await store.putFile(path.posix.join(app.slug, channel.id, 'versions.json'), Buffer.from(JSON.stringify(versionsToWrite, null, 2)), true);
+  }
+
   /**
    * This method compares to file names to determine if they are technically the same
    * file in the context of a single version/platform/arch combination.  This is used

--- a/src/db/BaseDriver.ts
+++ b/src/db/BaseDriver.ts
@@ -25,6 +25,7 @@ export abstract class IDBDriver {
   public abstract deleteWebHook(app: NucleusApp, webHookId: number): Promise<void>;
   public abstract createWebHookError(app: NucleusApp, webHookId: number, message: string, code: number, body: string): Promise<void>;
   public abstract setWebHookRegistered(app: NucleusApp, webHookId: number, registered: boolean): Promise<NucleusWebHook>;
+  public abstract setVersionDead(app: NucleusApp, channel: NucleusChannel, version: string, dead: boolean): Promise<NucleusChannel>;
 }
 
 export default abstract class BaseDriver extends IDBDriver {

--- a/src/db/sequelize/SequelizeDriver.ts
+++ b/src/db/sequelize/SequelizeDriver.ts
@@ -363,4 +363,24 @@ export default class SequelizeDriver extends BaseDriver {
     await webHook.save();
     return this.fixWebHookStruct(webHook);
   }
+
+  public async setVersionDead(app: NucleusApp, channel: NucleusChannel, versionName: string, dead: boolean) {
+    await this.ensureConnected();
+    const rawChannel = await Channel.findOne<Channel>({
+      where: {
+        appId: parseInt(app.id, 10),
+        stringId: channel.id,
+      },
+      include: [Version],
+    });
+    if (!rawChannel || !rawChannel.versions) return await this.getChannel(app, channel.id);
+    for (const version of rawChannel.versions) {
+      if (version.name === versionName) {
+        version.set('dead', dead);
+        await version.save();
+        break;
+      }
+    }
+    return this.fixChannelStruct(rawChannel.get());
+  }
 }

--- a/src/db/sequelize/SequelizeDriver.ts
+++ b/src/db/sequelize/SequelizeDriver.ts
@@ -5,8 +5,6 @@ import { Sequelize } from 'sequelize-typescript';
 import BaseDriver from '../BaseDriver';
 import getSequelize, { App, TeamMember, Channel, Version, File, TemporarySave, TemporarySaveFile, WebHook, WebHookError } from './models';
 
-import store from '../../files/store';
-
 const hat = require('hat');
 
 const includeSettings = {
@@ -305,8 +303,7 @@ export default class SequelizeDriver extends BaseDriver {
     const app = await App.findOne<App>({
       where: { id: rawChannel.appId },
     });
-    const versionsToWrite = Object.assign({}, (await this.getApp(app.id))).channels.find(testChannel => testChannel.id === rawChannel.stringId).versions;
-    await store.putFile(path.posix.join(app.slug, rawChannel.stringId, 'versions.json'), Buffer.from(JSON.stringify(versionsToWrite, null, 2)), true);
+    await this.writeVersionsFileToStore(this.fixAppStruct(app), this.fixChannelStruct(rawChannel));
     await this.deleteTemporarySave(save);
     return storedFileNames;
   }
@@ -381,6 +378,7 @@ export default class SequelizeDriver extends BaseDriver {
         break;
       }
     }
+    await this.writeVersionsFileToStore(app, channel);
     return this.fixChannelStruct(rawChannel.get());
   }
 }


### PR DESCRIPTION
This can be used inside apps to check whether or not it is OK to launch the current version of the app.  (Force updates onto users)

This is useful if a backend API has to go through a breaking change and you don't want hanging clients that will be a in a broken state.