### PR TITLE
fix(uploader): fix publisher syntax for forge

### DIFF
--- a/uploader/src/index.js
+++ b/uploader/src/index.js
@@ -4,7 +4,7 @@ const fetch = require('node-fetch');
 const path = require('path');
 
 const publisher = ({
-  artifactPaths: artifacts,
+  artifacts,
   packageJSON,
   forgeConfig,
   platform,


### PR DESCRIPTION
On my project, the uploader fails with an error message that artifacts isn't iteratable. Some investigation later it seems like the only time the string "artifactPaths" appears in electron-forge seems to be in the documentation, so I assume this is a copy-paste error introduced in 61ce545


I have signed the CLA to make lawyers happy