### PR TITLE
fix(public): change dialog text to be consistent with buttons

### DIFF
--- a/public/components/ChannelVersionList.tsx
+++ b/public/components/ChannelVersionList.tsx
@@ -301,7 +301,7 @@ export default class ChannelVersionList extends React.PureComponent<ChannelVersi
                 this.state.modalVersion.isPreRelease
                 ? (
                   <AkBanner icon={<WarningIcon label="Warning" />} isOpen>
-                    This is a set of pre-release files, click Publish to make them public
+                    This is a set of pre-release files, click Release to make them public
                   </AkBanner>
                 ) : null
               }


### PR DESCRIPTION
In the Release dialog, the button says "Release", but the text above it says "click Publish". Everything else also uses the word release (the word publish isn't used anywhere else in that file).