### PR TITLE
Update GPG signing params 

### DIFF
--- a/src/files/utils/gpg.ts
+++ b/src/files/utils/gpg.ts
@@ -19,7 +19,7 @@ export const gpgSign = async (file: string, out: string) => {
       throw new Error('Bad GPG import');
     }
     const keyId = keyMatch[1];
-    await cp.spawn('gpg', ['-abs', '--default-key', keyId, '-o', out, file]);
+    await cp.spawn('gpg', ['-abs','--digest-algo',  'SHA256', '--default-key', keyId, '-o', out, file]);
   });
 };
 


### PR DESCRIPTION
Fixes #51 
Set gpg preference during signing to SHA256 instead of SHA1 to avoid invalid signature errors when upgrading/installing using APT greater than 1.4~beta1. 