### PR TITLE
fix(public): fix dependencies failing to build on Ubuntu 18.04 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "semver": "^5.4.1",
     "sequelize": "^4.11.1",
     "sequelize-typescript": "^0.5.0",
-    "sqlite3": "^3.1.12",
+    "sqlite3": "^4.0.3",
     "tedious": "^2.0.0",
     "to-ico": "^1.1.5"
   },
@@ -116,7 +116,7 @@
     "html-webpack-plugin": "^2.28.0",
     "make-dir-cli": "^1.0.0",
     "mocha": "^3.5.3",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.9.4",
     "nodemon": "^1.11.0",
     "postcss-loader": "^2.0.5",
     "react": "^15.5.4",


### PR DESCRIPTION
Both SASS and SQlite3 failed to build on Ubuntu 18.04 LTS. This upgrades both dependencies to the current
version, fixing this problem.

Note that the sqlite update is an update by a whole major version. I haven't noticed any issues, but maybe you want to double-check.