### PR TITLE
docs: use public git url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then running your built docker image will run nucleus on port 8080.
 ### Manual
 
 ```bash
-git clone git@github.com:atlassian/nucleus.git nucleus-server
+git clone https://github.com/atlassian/nucleus.git nucleus-server
 cd nucleus-server
 cp config.template.js config.js
 yarn


### PR DESCRIPTION
the manual setup instructions in README.md suggest cloning from the authentificated repo url that
requires you to be authentificated with github. If you just want to install this needlessly
complicates things. I substituted the https url which can be used without authentification.