### PR TITLE
fix(file-store): store lock file non-publicly where possible

### DIFF
--- a/src/files/Positioner.ts
+++ b/src/files/Positioner.ts
@@ -256,7 +256,7 @@ export default class Positioner {
     const lock = hat();
     const currentLock = (await this.store.getFile(lockFile)).toString('utf8');
     if (currentLock === '') {
-      await this.store.putFile(lockFile, Buffer.from(lock), true);
+      await this.store.putFile(lockFile, Buffer.from(lock), true, false);
       return lock;
     }
     return null;

--- a/src/files/local/LocalStore.ts
+++ b/src/files/local/LocalStore.ts
@@ -10,7 +10,7 @@ export default class LocalStore implements IFileStore {
     return path.resolve(this.localConfig.root, ...keys);
   }
 
-  public async putFile(key: string, data: Buffer, overwrite = false) {
+  public async putFile(key: string, data: Buffer, overwrite = false, isPublic = true) {
     if (overwrite || !await fs.pathExists(this.getPath(key))) {
       await fs.mkdirp(path.dirname(this.getPath(key)));
       await fs.writeFile(this.getPath(key), data);

--- a/src/files/s3/S3Store.ts
+++ b/src/files/s3/S3Store.ts
@@ -36,8 +36,8 @@ export default class S3Store implements IFileStore {
     }));
   }
 
-  public async putFile(key: string, data: Buffer, overwrite = false) {
-    d(`Putting file: '${key}', overwrite=${overwrite ? 'true' : 'false'}`);
+  public async putFile(key: string, data: Buffer, overwrite = false, isPublic = true) {
+    d(`Putting file: '${key}', overwrite=${overwrite ? 'true' : 'false'}, public=${isPublic ? 'true' : 'false'}`);
     const s3 = new AWS.S3();
     const keyExists = async () => await this.hasFile(key);
     let wrote = false;
@@ -47,7 +47,7 @@ export default class S3Store implements IFileStore {
         Bucket: this.s3Config.bucketName,
         Key: key,
         Body: data,
-        ACL: 'public-read',
+        ACL: isPublic ? 'public-read' : 'private',
       }, (err, data) => {
         if (err) return reject(err);
         resolve();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -166,7 +166,7 @@ interface HandlePlatformUploadOpts {
 }
 
 interface IFileStore {
-  putFile(key: string, data: Buffer, overwriteExisting?: boolean): Promise<boolean>;
+  putFile(key: string, data: Buffer, overwriteExisting?: boolean, isPublic?: boolean): Promise<boolean>;
   hasFile(key: string): Promise<boolean>;
   getFile(key: string): Promise<Buffer>;
   getFileSize(key: string): Promise<number>;


### PR DESCRIPTION
This mainly benefits S3-compatible storage providers that make generous assumptions about the
cachability of public files (for example Google Cloud Storage). The lock file doesn't need to be
publicly readable, marking it as private sidesteps caching issues.

The newly introduced isPublic property could also be useful for future storage provider integrations, and could be used to prevent useless CDN updates. For that purpose it might be useful to mark prerelease files in the same way, though this isn't part of this patch.

Let me know if you think some other acl on the spectrum between public-read and private is more reasonable.

Even though I would be mildly surprised if anyone actually depends on the lock file being publicly visible, this is technically a breaking change.