### PR TITLE
fix(core-platform): fix file length computation

### DIFF
--- a/src/files/Positioner.ts
+++ b/src/files/Positioner.ts
@@ -78,6 +78,14 @@ export default class Positioner {
     if (file.arch !== 'ia32' && file.arch !== 'x64') return;
     d(`Handling upload (${file.fileName}) for app (${app.slug}) and channel (${channel.name}) for version (${internalVersion.name}) on platform/arch (${file.platform}/${file.arch})`);
 
+    if (!process.env.NO_NUCLEUS_INDEX) {
+      // Insert into file index for retreival later, this is purely to avoid making assumptions
+      // about file lifetimes for all platforms or assumptions about file positions or assumptions
+      // about file names containing version strings (which are currently enforced but may not be
+      // in the future)
+      await this.store.putFile(this.getIndexKey(app, channel, internalVersion, file), fileData);
+    }
+
     switch (file.platform) {
       case 'win32':
         await this.handleWindowsUpload({ app, channel, internalVersion, file, fileData });
@@ -90,14 +98,6 @@ export default class Positioner {
         break;
       default:
         return;
-    }
-
-    if (!process.env.NO_NUCLEUS_INDEX) {
-      // Insert into file index for retreival later, this is purely to avoid making assumptions
-      // about file lifetimes for all platforms or assumptions about file positions or assumptions
-      // about file names containing version strings (which are currently enforced but may not be
-      // in the future)
-      await this.store.putFile(this.getIndexKey(app, channel, internalVersion, file), fileData);
     }
   }
 


### PR DESCRIPTION
If uploading a Windows release with a .nuget file, handleWindowsUpload tries to get the file sizes of all released files. Those sizes are fetched from the index files, but the index files for the current release are only uploaded after handleWindowsUpload is called. Switching the order around seems to do the trick.

It also seems like setting NO_NUCLEUS_INDEX isn't really an option if you want to release windows files.