### PR TITLE
Remove instructions to use version 0.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ A configurable and versatile update server for all your Electron apps
   * Linux - RedHat
   * Linux - Debian
 
-## Stable Version
-
-The currently "stable" version is `v0.8.3`, unless you want a walk on the wild
-side.  Please stick to that release.
-
 ## Electron Version Requirements
 
 Please note that using Nucleus requires that you use Electron `>=2.0.0`.


### PR DESCRIPTION
Based on the discussion in #69 it sounds like the latest 1.x release is the recommended version to use. This diff removes those outdated instructions from the README.