### PR TITLE
fix: escape attachment names for draft release downloads

### DIFF
--- a/src/rest/app.ts
+++ b/src/rest/app.ts
@@ -256,7 +256,7 @@ router.get('/:id/channel/:channelId/temporary_releases/:temporarySaveId/:fileNam
   d(`User: ${req.user.id} requested an unencrypted version of a preRelease file: (${req.targetApp.slug}, ${save.version}, ${req.params.fileName})`);
   const positioner = new Positioner(store);
   const data = await positioner.getTemporaryFile(req.targetApp, save.saveString, req.params.fileName, save.cipherPassword);
-  res.setHeader('Content-disposition', `attachment; filename=${req.params.fileName}`);
+  res.setHeader('Content-disposition', `attachment; filename=${JSON.stringify(req.params.fileName)}`);
   res.status(200).write(data);
   res.send();
 }));


### PR DESCRIPTION
When you upload a release with a space in the name, the route that serves draft releases truncates the file name.

![image](https://user-images.githubusercontent.com/516559/74542291-26523880-4ef8-11ea-92b3-12af962d6914.png)

This happens because the file name isn't being escaped, so the `Content-disposition` directive ends with the space in the file name, and the rest of the file name is ignored by the browser.

The HTTP spec states that [filenames should be quoted strings](https://tools.ietf.org/html/rfc2616#section-19.5.1), so this PR `JSON.stringify`s the file name, which effectively quotes it.

After applying this fix, "draft" downloads with spaces in their names are able to be downloaded correctly.

![image](https://user-images.githubusercontent.com/516559/74543044-8e554e80-4ef9-11ea-91d7-d9ea1d8026c7.png)

I didn't see any tests for these endpoints, so I didn't add new ones (which would require some test app fixtures), but let me know if you'd prefer to have a test for this fix and I'll look at adding one