### PR TITLE
Allow SQL logging to be configured + add logs to publishing file version

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -30,6 +30,7 @@ module.exports = {
    * host: Hostname of database
    * port: Port to use when connecting
    * storage: Path to sqlite file, only used for sqlite dialect
+   * logging: Boolean indicating whether or not to output Sequelize logs (defaults to false)
    */
   sequelize: {
     dialect: 'sqlite',

--- a/src/db/sequelize/models/index.ts
+++ b/src/db/sequelize/models/index.ts
@@ -248,7 +248,7 @@ export default async function () {
     host: config.sequelize.host,
     port: config.sequelize.port,
     storage: config.sequelize.storage,
-    logging: false,
+    logging: config.sequelize.logging ? (msg: any) => d(msg) : false,
   });
 
   sequelize.addModels([

--- a/src/db/sequelize/models/index.ts
+++ b/src/db/sequelize/models/index.ts
@@ -248,7 +248,7 @@ export default async function () {
     host: config.sequelize.host,
     port: config.sequelize.port,
     storage: config.sequelize.storage,
-    logging: config.sequelize.logging ? (msg: any) => d(msg) : false,
+    logging: !!config.sequelize.logging,
   });
 
   sequelize.addModels([

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -39,6 +39,7 @@ interface SequelizeOptions {
   host: string;
   port: number;
   storage: string;
+  logging?: boolean;
 }
 
 interface LocalUser {


### PR DESCRIPTION
If `registerVersionFiles` fails when writing to the database, the error message is not clear (we see a `SequelizeUniqueConstraintError: Validation error`).  However there is no indication of which line is failing, or which column is failing the unique constraint. 