### PR TITLE
fix: long-running uploads are handled by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please note that using Nucleus requires that you use Electron `>=2.0.0`.
 
 ### Docker
 
-You'll need to set up your own docker image using a Dockefile like below.
+You'll need to set up your own docker image using a `Dockerfile` like below.
 
 ```docker
 FROM atlassian/nucleus
@@ -37,7 +37,7 @@ FROM atlassian/nucleus
 COPY config.js /opt/service/config.js
 ```
 
-Then running your built docker image will run nucleus on port 8080.
+Then running your built docker image will run nucleus on the port you configured (`default is 8080`).
 
 ### Manual
 
@@ -125,6 +125,8 @@ To enable logging you need to set `DEBUG=nucleus*`.
 * macOS / Windows
   * `docker`
   * `gpg`
+* Resources
+  * \>= 1.5GB RAM
 
 ## Contributors
 

--- a/config.template.js
+++ b/config.template.js
@@ -167,6 +167,16 @@ module.exports = {
     }
   },
 
+  /**
+   * The maximum amount of time (in milliseconds) that the webhooks should wait for POST and DELETE requests.
+   * 
+   * This is helpful if you're uploading with a slow connection or your application artifacts are very large.
+   * 
+   * If your upload duration exceeds this timeout setting then you will receive a socket hangup error.
+   */
+  webhookTimeout: 4000,
+
+
   organization: 'My Company Here',
 
   /**

--- a/src/__spec__/webhook_spec.ts
+++ b/src/__spec__/webhook_spec.ts
@@ -1,6 +1,7 @@
 import * as chai from 'chai';
 
 import * as helpers from './_helpers';
+import { webhookTimeout } from '../config';
 
 const { expect } = chai;
 
@@ -89,7 +90,7 @@ describe('webbhook endpoints', () => {
       });
 
       it('should succeed if a valid url and secret are provided', async function () {
-        this.timeout(4000);
+        this.timeout(webhookTimeout);
 
         const response = await helpers.request
           .post(`/app/${app.id}/webhook`)
@@ -110,7 +111,7 @@ describe('webbhook endpoints', () => {
   describe('/app/:id/webhook/:webhookId', () => {
     describe('DELETE', () => {
       it('should error if the webhook does not exist', async function () {
-        this.timeout(4000);
+        this.timeout(webhookTimeout);
 
         const response = await helpers.request
           .del(`/app/${app.id}/webhook/100`);
@@ -121,7 +122,7 @@ describe('webbhook endpoints', () => {
       });
 
       it('should unregister a valid webhook', async function () {
-        this.timeout(4000);
+        this.timeout(webhookTimeout);
 
         const response = await helpers.request
           .del(`/app/${app.id}/webhook/1`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ export const local = config!.local;
 export const sequelize = config!.sequelize;
 export const localAuth = config!.localAuth;
 export const sessionConfig = config!.sessionConfig;
+export const webhookTimeout = config!.webhookTimeout;
 export const organization = config!.organization;
 export const gpgSigningKey = config!.gpgSigningKey;
 export const defaultRollout = config!.defaultRollout || 0;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -74,6 +74,7 @@ interface IConfig {
   sequelize: SequelizeOptions;
   localAuth: LocalAuthOptions;
   sessionConfig: SessionConfig;
+  webhookTimeout: number;
   organization?: string;
   gpgSigningKey: string;
   defaultRollout: number;


### PR DESCRIPTION
Closes #90

This is to allow the user to configure uploads to be longer than 2 minutes without quitting them. 

This is especially important for situations where the internet speed can be slow or the files are large.