### PR TITLE
fix: upload timeout now configurable

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -11,6 +11,15 @@ module.exports = {
    */
   baseURL: 'http://localhost:8888',
 
+
+  /**
+   * Upload Timeout
+   * The timeout (in milliseconds) of the upload rest endpoint.  
+   * If the upload takes longer than the specified limit then the connection will close.
+   * If this happens then the release artifacts will be incomplete and left in a prerelease state and should be deleted manually.
+   */
+  uploadTimeout: 1800000,
+
   /**
    * The data store to use when persisting plugins and versions.  Current possible values
    * are "sequelize", ensure you also supply valid connection details for your

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,7 @@ if (!config) {
 
 export const port = config!.port;
 export const baseURL = config!.baseURL;
+export const uploadTimeout = config!.uploadTimeout || 1800000;
 export const fileStrategy = config!.fileStrategy;
 export const dbStrategy = config!.dbStrategy;
 export const github: GitHubOptions = config!.github || <any>{};

--- a/src/rest/app.ts
+++ b/src/rest/app.ts
@@ -473,8 +473,8 @@ router.post('/:id/channel/:channelId/upload', noPendingMigrations, upload.any(),
   req.setTimeout(uploadTimeout, () => {
     d(`Configured timeout of ${uploadTimeout}ms was exceeded.  Please check the server's "uploadTimeout" configuration for uploads.`);
     return res.status(408).json({
-        error: `Request timed out`
-      });
+      error: `Request timed out`,
+    });
   });
   const token = req.headers.authorization;
   if (token !== req.targetApp.token) {

--- a/src/rest/app.ts
+++ b/src/rest/app.ts
@@ -12,6 +12,7 @@ import { generateSHAs } from '../files/utils/sha';
 import WebHook from './WebHook';
 
 import { requireLogin, noPendingMigrations } from './_helpers';
+import { uploadTimeout } from '../config';
 
 const d = debug('nucleus:rest');
 const router = express();
@@ -469,6 +470,12 @@ router.post('/:id/channel/:channelId/rollout', requireLogin, noPendingMigrations
 }));
 
 router.post('/:id/channel/:channelId/upload', noPendingMigrations, upload.any(), a(async (req, res) => {
+  req.setTimeout(uploadTimeout, () => {
+    d(`Configured timeout of ${uploadTimeout}ms was exceeded.  Please check the server's "uploadTimeout" configuration for uploads.`);
+    return res.status(408).json({
+        error: `Request timed out`
+      });
+  });
   const token = req.headers.authorization;
   if (token !== req.targetApp.token) {
     return res.status(404).json({

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -63,6 +63,7 @@ interface SessionConfig {
 interface IConfig {
   port: number;
   baseURL: string;
+  uploadTimeout: number;
   fileStrategy: string;
   dbStrategy: string;
   authStrategy: string;


### PR DESCRIPTION
Closes #90 

The server was inheriting node js's http.server default timeout - which is 2 minutes.  

This is adequate for most  operations but was causing issues for long-running uploads, whether it be due to size or bandwith between the client/server or the server/s3 etc.

This PR 
* makes this timeout specifically for the `/:id/channel/:channelId/upload` route configurable in `config.js`
* adds documentation in config.template.js
* defaults to 30 minutes if the property is not found in `config.js` to enable compatibility with users of the current latest docker image.

I have tested this with an upload to s3 and it solves the problem neatly.  One thing I haven't been able to figure out is how to respond with a helpful error message, as I tried a few things but was still getting `socket hang up` from the client uploading to the server (electron-forge/nucleus publisher)