### PR TITLE
(fix) Electron forge's nucleus page link update

### DIFF
--- a/docs/Uploading.md
+++ b/docs/Uploading.md
@@ -6,7 +6,7 @@ The easiest way to upload releases to Nucleus is to use [`electron-forge`](https
 to build and publish your application.  You will find the config required
 on your App's page inside Nucleus.
 
-Check out the publisher documentation at [https://v6.electronforge.io/publishers/nucleus](https://v6.electronforge.io/publishers/nucleus)
+Check out the publisher documentation at [https://www.electronforge.io/config/publishers/nucleus](https://www.electronforge.io/config/publishers/nucleus)
 
 ## Custom Way
 


### PR DESCRIPTION
The previous link is not working, so this is the updated link from electron-forge' s official website to configure necleus